### PR TITLE
use-installer=true on remaining sam workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,13 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.8'
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '7.0.x'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: dotnet tool restore -v n
       - run: sam build
       - uses: actions/upload-artifact@v3
@@ -52,8 +51,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: sam-build
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.8'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: sam deploy

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,13 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.8'
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: dotnet tool restore -v n
       - run: sam build
       - uses: actions/upload-artifact@v3
@@ -52,9 +51,8 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: sam-build
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.8'
       - uses: aws-actions/setup-sam@v2
+        with:
+          use-installer: true
       - run: sam package
       - run: sam publish --semantic-version $GITHUB_REF_NAME


### PR DESCRIPTION
# Overview

Fix remaining GH workflows (deploy/publish) to align with changes from #25. This previous PR only updated the `build.yml` workflow, this will fix remaining GH workflows to align with the `sam-setup` action settings (using `with-installer: true`).